### PR TITLE
Add issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,65 @@
+name: Bug report
+description: Something in the app isn't working as expected
+labels: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug!
+
+        Please give the issue a short, plain-language title that describes the symptom — for example, "Cmd-M does not minimize on macOS". Technical detail and diagnosis are very welcome in the body below.
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: Describe what you did, what you expected to happen, and what happened instead.
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: If you can make the bug happen again, list the steps. Screenshots or a screen recording help a lot.
+      placeholder: |
+        1. Open a document…
+        2. …
+    validations:
+      required: false
+  - type: input
+    id: app-version
+    attributes:
+      label: App version
+      description: Find it in the About dialog — "tldraw offline → About" on macOS, or "Help → About" on Windows and Linux.
+      placeholder: e.g. 1.15.0
+    validations:
+      required: true
+  - type: dropdown
+    id: release-channel
+    attributes:
+      label: Release channel
+      options:
+        - Stable
+        - Nightly
+        - Not sure
+    validations:
+      required: false
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating system
+      options:
+        - macOS (Apple Silicon)
+        - macOS (Intel)
+        - Windows (x64)
+        - Windows (Arm)
+        - Linux (x86_64)
+        - Linux (Arm)
+    validations:
+      required: true
+  - type: textarea
+    id: extra
+    attributes:
+      label: Anything else?
+      description: OS version, logs, error messages, or anything else that might help.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,15 @@
+name: Feature request
+description: Suggest a new feature or improvement
+labels: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Have an idea for a feature or improvement? We'd love to hear it!
+  - type: textarea
+    id: description
+    attributes:
+      label: What's the feature?
+      description: Describe the feature, the problem it solves, and any examples from other apps.
+    validations:
+      required: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,3 @@
+Describe what your pull request does. If it fixes a bug, link the issue.
+
+### How was it tested?


### PR DESCRIPTION
Adds GitHub issue forms and a pull request template so reports arrive with the details triage needs up front.

- **Bug report form** — what happened, steps to reproduce, app version (with a pointer to the About dialog: "tldraw offline → About" on macOS, "Help → About" on Windows/Linux), release channel (stable/nightly), and OS/architecture matching the platforms we ship releases for. The intro nudges reporters toward short, plain-language, symptom-first titles.
- **Feature request form** — a single free-form description field.
- **config.yml** — keeps blank issues enabled, so free-form reports (including agent-filed ones) still work.
- **PR template** — minimal: what the change does and how it was tested.

Part of tldraw/tldraw-internal#861 (item 1).